### PR TITLE
fixed duplicate id

### DIFF
--- a/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramDebugger.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramDebugger.java
@@ -32,7 +32,7 @@ public class JettyProgramDebugger extends GenericDebuggerRunner {
 
     @NotNull
     public String getRunnerId() {
-        return "JettyRunner-By-GuiKeller";
+        return "JettyDebugger-By-GuiKeller";
     }
 
     public boolean canRun(@NotNull String value, @NotNull RunProfile runProfile) {


### PR DESCRIPTION
When I was running your plugin locally you get a duplicate id exception because the runner and debugger configuration had the same id.