### PR TITLE
add module selection configuration

### DIFF
--- a/src/main/java/com/github/guikeller/jettyrunner/model/JettyRunnerCommandLine.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/model/JettyRunnerCommandLine.java
@@ -1,6 +1,5 @@
 package com.github.guikeller.jettyrunner.model;
 
-import com.github.guikeller.jettyrunner.model.JettyRunnerConfiguration;
 import com.intellij.execution.ExecutionException;
 import com.intellij.execution.configurations.JavaCommandLineState;
 import com.intellij.execution.configurations.JavaParameters;
@@ -48,8 +47,12 @@ public class JettyRunnerCommandLine extends JavaCommandLineState {
         // All modules to use the same things
         Module[] modules = ModuleManager.getInstance(project).getModules();
         if (modules != null && modules.length > 0) {
+            String selectedModule = model.getModule();
             for (Module module : modules) {
-                javaParams.configureByModule(module, JavaParameters.JDK_AND_CLASSES);
+                // add this module if no filter defined by the user or if this module is the filtered one!
+                if (selectedModule == null || selectedModule.isEmpty() || module.getName().equals(selectedModule)) {
+                    javaParams.configureByModule(module, JavaParameters.JDK_AND_CLASSES);
+                }
             }
         }
         // Dynamically adds the jetty-runner.jar to the classpath

--- a/src/main/java/com/github/guikeller/jettyrunner/model/JettyRunnerConfiguration.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/model/JettyRunnerConfiguration.java
@@ -35,6 +35,7 @@ public class JettyRunnerConfiguration extends LocatableConfigurationBase impleme
     public static final String WEBAPP_FOLDER_FIELD = PREFIX + "WebAppFolder";
     public static final String CLASSES_DIRECTORY_FIELD = PREFIX + "ClassesDirectory";
     public static final String RUN_PORT_FIELD = PREFIX + "RunOnPort";
+    public static final String MODULE_FIELD = PREFIX + "Module";
     public static final String JETTY_XML_FIELD = PREFIX + "JettyXML";
     public static final String VM_ARGS_FIELD = PREFIX + "VmArgs";
     public static final String PASS_PARENT_ENV_VARS_FIELD = PREFIX + "PassParentEnvVars";
@@ -44,6 +45,7 @@ public class JettyRunnerConfiguration extends LocatableConfigurationBase impleme
     private String classesDirectories;
 
     private String runningOnPort;
+    private String module;
     private String jettyXml;
     private String vmArgs;
 
@@ -82,6 +84,7 @@ public class JettyRunnerConfiguration extends LocatableConfigurationBase impleme
         this.webappFolders = JDOMExternalizerUtil.readField(element, WEBAPP_FOLDER_FIELD);
         this.classesDirectories = JDOMExternalizerUtil.readField(element, CLASSES_DIRECTORY_FIELD);
         this.runningOnPort = JDOMExternalizerUtil.readField(element, RUN_PORT_FIELD);
+        this.module = JDOMExternalizerUtil.readField(element, MODULE_FIELD);
         this.jettyXml = JDOMExternalizerUtil.readField(element, JETTY_XML_FIELD);
         this.vmArgs = JDOMExternalizerUtil.readField(element, VM_ARGS_FIELD);
         String passParentEnvironmentVariablesValue = JDOMExternalizerUtil.readField(element, PASS_PARENT_ENV_VARS_FIELD);
@@ -97,6 +100,7 @@ public class JettyRunnerConfiguration extends LocatableConfigurationBase impleme
         JDOMExternalizerUtil.writeField(element, WEBAPP_FOLDER_FIELD, this.getWebappFolders());
         JDOMExternalizerUtil.writeField(element, CLASSES_DIRECTORY_FIELD, this.getClassesDirectories());
         JDOMExternalizerUtil.writeField(element, RUN_PORT_FIELD, this.getRunningOnPort());
+        JDOMExternalizerUtil.writeField(element, MODULE_FIELD, this.getModule());
         JDOMExternalizerUtil.writeField(element, JETTY_XML_FIELD, this.getJettyXml());
         JDOMExternalizerUtil.writeField(element, VM_ARGS_FIELD, this.getVmArgs());
         JDOMExternalizerUtil.writeField(element, PASS_PARENT_ENV_VARS_FIELD, ""+this.isPassParentEnvironmentVariables());
@@ -140,6 +144,14 @@ public class JettyRunnerConfiguration extends LocatableConfigurationBase impleme
 
     public String getRunningOnPort() {
         return runningOnPort;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public void setModule(String module) {
+        this.module = module;
     }
 
     public void setRunningOnPort(String runningOnPort) {

--- a/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.form
+++ b/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.form
@@ -27,6 +27,8 @@
         <rowspec value="center:max(d;4px):noGrow"/>
         <rowspec value="top:4dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
+        <rowspec value="top:4dlu:noGrow"/>
+        <rowspec value="center:max(d;4px):noGrow"/>
         <rowspec value="top:3dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
         <rowspec value="top:4dlu:noGrow"/>
@@ -121,26 +123,6 @@
               <toolTipText value="Eg: /path/to/target/classes (Accepts multiple values) [Mandatory - CSV]"/>
             </properties>
           </component>
-          <component id="72ca3" class="javax.swing.JLabel" binding="runOnPortLabel">
-            <constraints>
-              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
-              <forms defaultalign-horz="false"/>
-            </constraints>
-            <properties>
-              <text value="Runs on Port:"/>
-            </properties>
-          </component>
-          <component id="7395a" class="javax.swing.JTextField" binding="runOnPortField">
-            <constraints>
-              <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
-                <preferred-size width="150" height="-1"/>
-              </grid>
-              <forms defaultalign-horz="false"/>
-            </constraints>
-            <properties>
-              <toolTipText value="Eg: 8080 (Single value) [Mandatory]"/>
-            </properties>
-          </component>
           <component id="ea82" class="javax.swing.JLabel" binding="xmlLabel">
             <constraints>
               <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
@@ -175,7 +157,7 @@
           </component>
           <component id="d05a7" class="javax.swing.JLabel" binding="spacerLabel">
             <constraints>
-              <grid row="16" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
               <forms/>
             </constraints>
             <properties>
@@ -186,7 +168,7 @@
           </component>
           <component id="c3534" class="com.intellij.execution.configuration.EnvironmentVariablesComponent" binding="environmentVariables">
             <constraints>
-              <grid row="20" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="22" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
               <forms/>
             </constraints>
             <properties>
@@ -196,7 +178,7 @@
           </component>
           <component id="a4aff" class="javax.swing.JLabel" binding="vmArgsLabel">
             <constraints>
-              <grid row="18" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="20" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -205,7 +187,7 @@
           </component>
           <component id="40a52" class="javax.swing.JTextField" binding="vmArgsField">
             <constraints>
-              <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="20" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -216,12 +198,52 @@
           </component>
           <component id="3011f" class="javax.swing.JLabel" binding="envVarLabel">
             <constraints>
-              <grid row="20" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="22" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
               <text value="Env Vars:"/>
               <toolTipText value="Warning: Experimental feature, use with extreme caution."/>
+            </properties>
+          </component>
+          <component id="7395a" class="javax.swing.JTextField" binding="runOnPortField">
+            <constraints>
+              <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+              <forms defaultalign-horz="false"/>
+            </constraints>
+            <properties>
+              <toolTipText value="Eg: 8080 (Single value) [Mandatory]"/>
+            </properties>
+          </component>
+          <component id="72ca3" class="javax.swing.JLabel" binding="runOnPortLabel">
+            <constraints>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <forms defaultalign-horz="false"/>
+            </constraints>
+            <properties>
+              <text value="Runs on Port:"/>
+            </properties>
+          </component>
+          <component id="6667395a" class="javax.swing.JTextField" binding="moduleField">
+            <constraints>
+              <grid row="16" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                <preferred-size width="150" height="-1"/>
+              </grid>
+              <forms defaultalign-horz="false"/>
+            </constraints>
+            <properties>
+              <toolTipText value="Eg: x-webapp. Can be empty, if empty the plugin use all modules to create the classpath"/>
+            </properties>
+          </component>
+          <component id="66672ca3" class="javax.swing.JLabel" binding="moduleLabel">
+            <constraints>
+              <grid row="16" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <forms defaultalign-horz="false"/>
+            </constraints>
+            <properties>
+              <text value="Module name:"/>
             </properties>
           </component>
         </children>

--- a/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.java
@@ -3,13 +3,9 @@ package com.github.guikeller.jettyrunner.ui;
 import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 
 import javax.swing.*;
-import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.File;
-import java.net.URL;
 
 /**
  * View / Presentation - Created using the WYSIWYG editor.
@@ -23,6 +19,7 @@ public class JettyRunnerConfPanel {
     private JTextField webappField;
     private JTextField classesField;
     private JTextField runOnPortField;
+    private JTextField moduleField;
     private JTextField xmlField;
     private JButton browseButton;
     private JTextField vmArgsField;
@@ -32,6 +29,7 @@ public class JettyRunnerConfPanel {
     private JLabel firstMsgLabel;
     private JLabel xmlLabel;
     private JLabel runOnPortLabel;
+    private JLabel moduleLabel;
     private JLabel classesLabel;
     private JLabel webappLabel;
     private JLabel pathLabel;
@@ -82,6 +80,10 @@ public class JettyRunnerConfPanel {
 
     public JTextField getRunOnPortField() {
         return runOnPortField;
+    }
+
+    public JTextField getModuleField() {
+        return moduleField;
     }
 
     public JTextField getXmlField() {

--- a/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerEditor.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerEditor.java
@@ -78,6 +78,13 @@ public class JettyRunnerEditor extends SettingsEditor<JettyRunnerConfiguration> 
         } else {
             this.configurationPanel.getRunOnPortField().setText("8080");
         }
+        // Runs module
+        String module = jettyRunnerConfiguration.getModule();
+        if (module != null && !"".equals(module)) {
+            this.configurationPanel.getModuleField().setText(module);
+        } else {
+            this.configurationPanel.getModuleField().setText("");
+        }
         // Jetty XML (Optional)
         this.configurationPanel.getXmlField().setText(jettyRunnerConfiguration.getJettyXml());
         // Env Vars (Optional)
@@ -100,6 +107,7 @@ public class JettyRunnerEditor extends SettingsEditor<JettyRunnerConfiguration> 
         jettyRunnerConfiguration.setWebappFolders(this.configurationPanel.getWebappField().getText());
         jettyRunnerConfiguration.setClassesDirectories(this.configurationPanel.getClassesField().getText());
         jettyRunnerConfiguration.setRunningOnPort(this.configurationPanel.getRunOnPortField().getText());
+        jettyRunnerConfiguration.setModule(this.configurationPanel.getModuleField().getText());
         jettyRunnerConfiguration.setJettyXml(this.configurationPanel.getXmlField().getText());
         jettyRunnerConfiguration.setVmArgs(this.configurationPanel.getVmArgsField().getText());
         jettyRunnerConfiguration.setPassParentEnvironmentVariables(this.configurationPanel.getEnvironmentVariables().isPassParentEnvs());

--- a/src/test/java/com/github/guikeller/jettyrunner/ui/JettyRunnerEditorTest.java
+++ b/src/test/java/com/github/guikeller/jettyrunner/ui/JettyRunnerEditorTest.java
@@ -36,6 +36,9 @@ public class JettyRunnerEditorTest {
         JTextField runOnPortField = Mockito.mock(JTextField.class);
         Mockito.when(confPanel.getRunOnPortField()).thenReturn(runOnPortField);
 
+        JTextField moduleField = Mockito.mock(JTextField.class);
+        Mockito.when(confPanel.getModuleField()).thenReturn(moduleField);
+
         JTextField xmlField = Mockito.mock(JTextField.class);
         Mockito.when(confPanel.getXmlField()).thenReturn(xmlField);
 


### PR DESCRIPTION
Hi guikeller, when i have 2 or more webapp modules in the same intellij project, jetty runner creates the classpath based on all the project modules. So, if i have a duplicated resource (for example an application.properties) in those webapp modules there is a conflict.

I have commited a basic module configuration in my fork (branch module-selection-configuration). Please, check it and merge it if you think is helpful for other developers... or ask me for modifications if something is wrong.

Thanks in advance and great job!