### PR TITLE
allow to use classpath of all modules (default) or classpath of one module only

### DIFF
--- a/src/main/java/com/github/guikeller/jettyrunner/model/JettyRunnerCommandLine.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/model/JettyRunnerCommandLine.java
@@ -5,7 +5,6 @@ import com.intellij.execution.configurations.JavaCommandLineState;
 import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.openapi.module.Module;
-import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.util.PathUtil;
@@ -44,8 +43,9 @@ public class JettyRunnerCommandLine extends JavaCommandLineState {
         Project project = this.environment.getProject();
         ProjectRootManager manager = ProjectRootManager.getInstance(project);
         javaParams.setJdk(manager.getProjectSdk());
+
         // All modules to use the same things
-        Module[] modules = ModuleManager.getInstance(project).getModules();
+        Module[] modules = this.model.getModules();
         if (modules != null && modules.length > 0) {
             for (Module module : modules) {
                 javaParams.configureByModule(module, JavaParameters.JDK_AND_CLASSES);

--- a/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.form
+++ b/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.form
@@ -4,12 +4,14 @@
     <rowspec value="center:d:noGrow"/>
     <colspec value="fill:d:grow"/>
     <constraints>
-      <xy x="20" y="20" width="509" height="402"/>
+      <xy x="20" y="20" width="509" height="470"/>
     </constraints>
     <properties/>
     <border type="none"/>
     <children>
       <grid id="d33f1" layout-manager="FormLayout">
+        <rowspec value="center:max(d;4px):noGrow"/>
+        <rowspec value="top:4dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
         <rowspec value="top:4dlu:noGrow"/>
         <rowspec value="center:max(d;4px):noGrow"/>
@@ -63,7 +65,7 @@
           </component>
           <component id="fd53a" class="javax.swing.JLabel" binding="pathLabel">
             <constraints>
-              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -72,7 +74,7 @@
           </component>
           <component id="9b7e9" class="javax.swing.JTextField" binding="pathField">
             <constraints>
-              <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -83,7 +85,7 @@
           </component>
           <component id="6a4fd" class="javax.swing.JLabel" binding="webappLabel">
             <constraints>
-              <grid row="6" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -92,7 +94,7 @@
           </component>
           <component id="4dc77" class="javax.swing.JTextField" binding="webappField">
             <constraints>
-              <grid row="6" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="8" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -103,7 +105,7 @@
           </component>
           <component id="c6409" class="javax.swing.JLabel" binding="classesLabel">
             <constraints>
-              <grid row="8" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -112,7 +114,7 @@
           </component>
           <component id="45498" class="javax.swing.JTextField" binding="classesField">
             <constraints>
-              <grid row="8" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -123,7 +125,7 @@
           </component>
           <component id="72ca3" class="javax.swing.JLabel" binding="runOnPortLabel">
             <constraints>
-              <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -132,7 +134,7 @@
           </component>
           <component id="7395a" class="javax.swing.JTextField" binding="runOnPortField">
             <constraints>
-              <grid row="10" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="12" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -143,7 +145,7 @@
           </component>
           <component id="ea82" class="javax.swing.JLabel" binding="xmlLabel">
             <constraints>
-              <grid row="12" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="14" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -152,7 +154,7 @@
           </component>
           <component id="43c70" class="javax.swing.JTextField" binding="xmlField">
             <constraints>
-              <grid row="12" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -165,7 +167,7 @@
           </component>
           <component id="6d85a" class="javax.swing.JButton" binding="browseButton">
             <constraints>
-              <grid row="14" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+              <grid row="16" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
               <forms/>
             </constraints>
             <properties>
@@ -175,7 +177,7 @@
           </component>
           <component id="d05a7" class="javax.swing.JLabel" binding="spacerLabel">
             <constraints>
-              <grid row="16" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
               <forms/>
             </constraints>
             <properties>
@@ -186,7 +188,7 @@
           </component>
           <component id="c3534" class="com.intellij.execution.configuration.EnvironmentVariablesComponent" binding="environmentVariables">
             <constraints>
-              <grid row="20" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="22" column="2" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="0" indent="0" use-parent-layout="false"/>
               <forms/>
             </constraints>
             <properties>
@@ -196,7 +198,7 @@
           </component>
           <component id="a4aff" class="javax.swing.JLabel" binding="vmArgsLabel">
             <constraints>
-              <grid row="18" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="20" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
@@ -205,7 +207,7 @@
           </component>
           <component id="40a52" class="javax.swing.JTextField" binding="vmArgsField">
             <constraints>
-              <grid row="18" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+              <grid row="20" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
                 <preferred-size width="150" height="-1"/>
               </grid>
               <forms defaultalign-horz="false"/>
@@ -216,12 +218,34 @@
           </component>
           <component id="3011f" class="javax.swing.JLabel" binding="envVarLabel">
             <constraints>
-              <grid row="20" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <grid row="22" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
               <forms defaultalign-horz="false"/>
             </constraints>
             <properties>
               <text value="Env Vars:"/>
               <toolTipText value="Warning: Experimental feature, use with extreme caution."/>
+            </properties>
+          </component>
+          <component id="c049c" class="javax.swing.JLabel" binding="moduleLabel">
+            <constraints>
+              <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="4" fill="0" indent="0" use-parent-layout="false"/>
+              <forms defaultalign-horz="false"/>
+            </constraints>
+            <properties>
+              <enabled value="true"/>
+              <horizontalTextPosition value="11"/>
+              <text value="Module:"/>
+            </properties>
+          </component>
+          <component id="20109" class="javax.swing.JComboBox" binding="moduleComboBox">
+            <constraints>
+              <grid row="4" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+              <forms/>
+            </constraints>
+            <properties>
+              <model>
+                <item value="&lt;all modules&gt;"/>
+              </model>
             </properties>
           </component>
         </children>

--- a/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/ui/JettyRunnerConfPanel.java
@@ -3,13 +3,7 @@ package com.github.guikeller.jettyrunner.ui;
 import com.intellij.execution.configuration.EnvironmentVariablesComponent;
 
 import javax.swing.*;
-import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.MouseAdapter;
-import java.awt.event.MouseEvent;
 import java.io.File;
-import java.net.URL;
 
 /**
  * View / Presentation - Created using the WYSIWYG editor.
@@ -37,6 +31,8 @@ public class JettyRunnerConfPanel {
     private JLabel pathLabel;
     private JLabel secondMsgLabel;
     private JLabel envVarLabel;
+    private JLabel moduleLabel;
+    private JComboBox<String> moduleComboBox;
 
     public JettyRunnerConfPanel() {
         // Action executed when clicked on "Browse XML"
@@ -94,4 +90,7 @@ public class JettyRunnerConfPanel {
         return environmentVariables;
     }
 
+    public JComboBox<String> getModuleComboBox() {
+        return moduleComboBox;
+    }
 }

--- a/src/test/java/com/github/guikeller/jettyrunner/ui/JettyRunnerEditorTest.java
+++ b/src/test/java/com/github/guikeller/jettyrunner/ui/JettyRunnerEditorTest.java
@@ -24,6 +24,10 @@ public class JettyRunnerEditorTest {
 
         JettyRunnerConfPanel confPanel = Mockito.mock(JettyRunnerConfPanel.class);
 
+        @SuppressWarnings("unchecked")
+        JComboBox<String> moduleComboBox = Mockito.mock(JComboBox.class);
+        Mockito.when(confPanel.getModuleComboBox()).thenReturn(moduleComboBox);
+
         JTextField pathField = Mockito.mock(JTextField.class);
         Mockito.when(confPanel.getPathField()).thenReturn(pathField);
 
@@ -58,6 +62,7 @@ public class JettyRunnerEditorTest {
             }
         }
 
+        Mockito.verify(confPanel, Mockito.times(1)).getModuleComboBox();
         Mockito.verify(confPanel, Mockito.times(1)).getClassesField();
         Mockito.verify(confPanel, Mockito.times(1)).getPathField();
         Mockito.verify(confPanel, Mockito.times(1)).getWebappField();


### PR DESCRIPTION
This MR closes totally #57 and partially #52 

- Add a "module" combobox field to the UI. Available options:
   - `<all modules>` (default value): uses the classpath of all the modules in the IntelliJ instance
   - one entry per module present in the IntelliJ instance, in order to use the classpath of the selected module only
