### PR TITLE
Fixed a bug: Debug cannot work when Debug use JettyRunnerConfiguration

### DIFF
--- a/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramDebugger.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramDebugger.java
@@ -7,7 +7,6 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.*;
 import com.intellij.execution.executors.DefaultDebugExecutor;
-import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramDebugger.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramDebugger.java
@@ -7,6 +7,7 @@ import com.intellij.execution.ExecutionException;
 import com.intellij.execution.Executor;
 import com.intellij.execution.configurations.*;
 import com.intellij.execution.executors.DefaultDebugExecutor;
+import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.runners.ExecutionEnvironment;
 import com.intellij.execution.ui.RunContentDescriptor;
 import org.jetbrains.annotations.NotNull;
@@ -35,9 +36,9 @@ public class JettyProgramDebugger extends GenericDebuggerRunner {
     }
 
     @Override
-    public boolean canRun(@NotNull String value, @NotNull RunProfile runProfile) {
+    public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
         // It can only run JettyRunnerConfigurations
-        return runProfile instanceof JettyRunnerConfiguration;
+        return executorId.equals(DefaultDebugExecutor.EXECUTOR_ID) && runProfile instanceof JettyRunnerConfiguration;
     }
 
     @Override

--- a/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramRunner.java
+++ b/src/main/java/com/github/guikeller/jettyrunner/runner/JettyProgramRunner.java
@@ -2,6 +2,7 @@ package com.github.guikeller.jettyrunner.runner;
 
 import com.github.guikeller.jettyrunner.model.JettyRunnerConfiguration;
 import com.intellij.execution.configurations.RunProfile;
+import com.intellij.execution.executors.DefaultRunExecutor;
 import com.intellij.execution.impl.DefaultJavaProgramRunner;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,9 +24,9 @@ public class JettyProgramRunner extends DefaultJavaProgramRunner {
     }
 
     @Override
-    public boolean canRun(@NotNull String value, @NotNull RunProfile runProfile) {
+    public boolean canRun(@NotNull String executorId, @NotNull RunProfile runProfile) {
         // It can only run JettyRunnerConfigurations
-        return runProfile instanceof JettyRunnerConfiguration;
+        return executorId.equals(DefaultRunExecutor.EXECUTOR_ID) && runProfile instanceof JettyRunnerConfiguration;
     }
 
 }


### PR DESCRIPTION
Fixed a bug: Debug cannot work when Debug use JettyRunnerConfiguration

like the issue: [Doesn't stop at breakpoints on IntelliJ 2020.1](https://github.com/guikeller/jetty-runner/issues/71)

- [`com.intellij.execution.runners.ProgramRunner`](https://github.com/JetBrains/intellij-community/blob/834b8ad1e912f446fe319df4168f53b56af84dda/platform/execution/src/com/intellij/execution/runners/ProgramRunner.java#L41) find first Runner，so Runner must task `executorId` into consideration
```
  @Nullable
  static ProgramRunner<RunnerSettings> getRunner(@NotNull String executorId, @NotNull RunProfile settings) {
    //noinspection unchecked
    return (ProgramRunner<RunnerSettings>)PROGRAM_RUNNER_EP.findFirstSafe(it -> it.canRun(executorId, settings));
  }
```